### PR TITLE
Ensure file handles close and clarify comments

### DIFF
--- a/ProjectsManagerPlus.DebugLogHelper.pas
+++ b/ProjectsManagerPlus.DebugLogHelper.pas
@@ -13,7 +13,7 @@ type
   public
     class var Prefix: string;
     /// <summary>
-    /// Envia mensagem para o DebugView com prefixo padr„o, thread ID e timestamp.
+    /// Envia mensagem para o DebugView com prefixo padr√£o, thread ID e timestamp.
     /// </summary>
     class procedure Log(const AMessage: string; ALevel: TLogLevel = llInfo); static;
     class procedure LogFmt(const ALevel: TLogLevel; const AFormat: string; const AArgs: array of const); static;

--- a/ProjectsManagerPlus.Menu.pas
+++ b/ProjectsManagerPlus.Menu.pas
@@ -205,7 +205,7 @@ var
 begin
   TDebugLog.Log('ProjectsManagerPlus: Execute called for MenuType: ' + FMenuType);
 
-  // Get menu context - use project path as default
+  // Determine project path; menu context currently ignored
   LSelectedPath := '';
   if Assigned(FProject) then
     LProjectPath := ExtractFilePath(FProject.FileName)

--- a/ProjectsManagerPlus.Services.pas
+++ b/ProjectsManagerPlus.Services.pas
@@ -26,13 +26,16 @@ var
   LFile: TextFile;
 begin
   Result := False;
+  AssignFile(LFile, APath);
   try
-    AssignFile(LFile, APath);
     Rewrite(LFile);
-    if AContent <> '' then
-      Write(LFile, AContent);
-    CloseFile(LFile);
-    Result := True;
+    try
+      if AContent <> '' then
+        Write(LFile, AContent);
+      Result := True;
+    finally
+      CloseFile(LFile);
+    end;
   except
     on E: Exception do
       Result := False;

--- a/Tests/TestFileServiceCreateFile.pas
+++ b/Tests/TestFileServiceCreateFile.pas
@@ -1,0 +1,25 @@
+program TestFileServiceCreateFile;
+
+{$APPTYPE CONSOLE}
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  ProjectsManagerPlus.Services;
+
+var
+  LPath: string;
+  LContent: string;
+  LResult: Boolean;
+begin
+  LPath := 'TestOutput.txt';
+  LContent := 'hello world';
+  LResult := TFileService.CreateFile(LPath, LContent);
+  if LResult and TFile.Exists(LPath) and (TFile.ReadAllText(LPath) = LContent) then
+    Writeln('PASS: file created with expected content')
+  else
+    Writeln('FAIL: file not created or content mismatch');
+  if TFile.Exists(LPath) then
+    TFile.Delete(LPath);
+end.
+


### PR DESCRIPTION
## Summary
- fix typo in debug log helper comment
- protect file creation with try/finally to close handle
- clarify menu context comment and add basic file service test

## Testing
- `fpc Tests/TestFileServiceCreateFile.pas` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcc86995083228f2635e8d42ac7e2